### PR TITLE
Support specifying a base url for remote urls

### DIFF
--- a/lib/dragonfly/data_storage/remote_data_store.rb
+++ b/lib/dragonfly/data_storage/remote_data_store.rb
@@ -1,4 +1,5 @@
 require 'httparty'
+require 'uri'
 
 module Dragonfly
   module DataStorage
@@ -6,13 +7,14 @@ module Dragonfly
     
     class RemoteDataStore
       include Configurable
-      
+      configurable_attr :url_host
+
       def store(temp_object, opts={})
         raise "Sorry friend, this datastore is read-only."
       end
 
       def retrieve(uid)
-        response = HTTParty.get uid, :timeout => 3
+        response = HTTParty.get URI::join(url_host.to_s, uid).to_s, :timeout => 3
         unless response.ok?
           #raise Forbidden if response.code == 403
           raise DataNotFound

--- a/spec/unit/remote_data_store_spec.rb
+++ b/spec/unit/remote_data_store_spec.rb
@@ -20,6 +20,21 @@ describe Dragonfly::DataStorage::RemoteDataStore do
       image,extra = datastore.retrieve(url)
       image.should eq IO.read(image_path)
     end
+
+    it "should fetch the image based on the url_host variable" do
+      path = "foo/bar/iamgemagick.png"
+      url_host = "http://www.foo.com/"
+      url = url_host + path
+      stub_request(:get, url)
+
+      datastore = Dragonfly::DataStorage::RemoteDataStore.new
+      datastore.configure do |c|
+        c.url_host = url_host
+      end
+
+      datastore.retrieve path
+      a_request(:get, url).should have_been_made.once
+    end
   end
 end
 


### PR DESCRIPTION
For example:

```
app.datastore.configure do |c|
  c.url_host = 'http://assets.domain.com/'
end
```
