### PR TITLE
Introduce "Clean" (/c) and "Query Clean" (/qc) Routes To Magickly

### DIFF
--- a/lib/magickly.rb
+++ b/lib/magickly.rb
@@ -22,6 +22,14 @@ module Magickly
   end
 
   class << self
+    def origin_host
+      @origin_host
+    end
+
+    def origin_host=(s)
+      @origin_host = s
+    end
+
     def dragonfly
       @dragonfly
     end

--- a/lib/magickly/app.rb
+++ b/lib/magickly/app.rb
@@ -29,6 +29,25 @@ module Magickly
       process_path request.path_info.sub /^\/q\//, ''
     end
 
+    get '/c/src/*' do
+      src = params[:splat].last
+      src = "#{Magickly.origin_host}/#{src}"
+      process_src_or_display_demo src, ordered_options
+    end
+
+    get '/qc/*/src/*' do
+      src = params[:splat].last
+      src = "#{Magickly.origin_host}/#{src}"
+      path = request.path_info
+
+      # Replace the qs argument with nothing
+      path.sub! /^\/qc\//, ''
+      # Replace the src with a fully qualified escaped url to allow for process path to work as is.
+      path.sub! /\/src\/.*/, "/src/#{CGI.escape(src)}"
+
+      process_path path
+    end
+
     get '/qe/*' do
       # TODO use Base64.urlsafe_decode64
       decoded = request.path_info.sub /^\/qe\//, ''

--- a/spec/requests/magickly_app_spec.rb
+++ b/spec/requests/magickly_app_spec.rb
@@ -136,6 +136,38 @@ describe Magickly::App do
 
   end
 
+  describe "GET /c/src/*" do
+
+    it "resizes an image" do
+      Magickly.origin_host = 'http://www.foo.com'
+      setup_image
+      width = 100
+
+      file = get_image "/c/src/#{@image_filename}?resize=#{width}x"
+
+      expect(a_request(:get, @image_url)).to have_been_made.once
+      expect(last_response.status).to eq(200)
+      expect(FastImage.size(file)[0]).to eq width
+    end
+
+  end
+
+  describe "GET /qc/*/src/*" do
+
+    it "resizes an image" do
+      Magickly.origin_host = 'http://www.foo.com'
+      setup_image
+      width = 100
+
+      file = get_image "/qc/resize/#{width}/flip/true/src/#{@image_filename}"
+
+      expect(a_request(:get, @image_url)).to have_been_made.once
+      expect(last_response.status).to eq(200)
+      expect(FastImage.size(file)[0]).to eq width
+    end
+
+  end
+
   describe "GET /qe" do
 
     it "resized an image" do


### PR DESCRIPTION
This PR creates two new routes that allow the URL for the resized to image to look a bit cleaner. The inspiration was the Imgix API which basically makes a trade off on host flexibility for a cleaner URL. The motivation for this is that as mentioned in the docs, the src=? in the query string may get screwed up by certain CDN. However the URI encoding feature (`/q/`) may create an URL that is suspicious by certain email clients and get marked as spam. The Base64 encoding feature (`/qe/`) solves it all, but create an URL that is hard for a Marketing team, external developers to "play around with" with the various options.

This change adds the following and hopes to make things safe but still easy to play with.

1) A `origin_host` config to prepend to all src URLs.

```
Magickly.origin_host = 'http://d1zo0hr4fmj52a.cloudfront.net'
```

2) A `/c/src` that allows us to use the src image in the URL with standard Magickly query string API.

```
http://localhost:8080/magickly/c/src/recipes/model_id/recipe_ingredient_images/60335ed9-084b-4e34-b189-d6ce4cf0dbf2/Honey-1TB.jpg?resize=256x&grayscale=true
```

3) A ```/qc/*/src/*` that allows for the manipulation params to be in URL segments, and the source image to be at the end.

```
http://localhost:8080/magickly/qc/resize/300/src/recipes/model_id/recipe_ingredient_images/60335ed9-084b-4e34-b189-d6ce4cf0dbf2/Honey-1TB.jpg
```

My hope is that these changes continue to keep things easy and flexible in Magickly.

Also wanted to say this is a great project and we look forward to using it for all our image resizing needs.
